### PR TITLE
背景遮罩透明度改成暗色模式背景遮罩强度，增加亮色模式背景遮罩强度

### DIFF
--- a/komari-theme.json
+++ b/komari-theme.json
@@ -10,32 +10,190 @@
     "type": "managed",
     "name": "Emerald 设置",
     "data": [
-      { "name": "基础设置", "type": "title" },
-      { "key": "dataUpdateInterval", "name": "数据更新间隔", "type": "number", "default": 3, "help": "实时数据刷新间隔，单位：秒（建议 1-10 秒）" },
-      { "key": "rpcTransportMode", "name": "RPC 连接模式", "type": "select", "default": "websocket", "options": "websocket,http", "help": "RPC 默认连接模式，推荐使用 websocket，若您无法使用 websocket 请选择 http" },
-      { "key": "defaultViewMode", "name": "默认视图模式", "type": "select", "default": "card", "options": "card,list", "help": "节点列表的默认显示模式" },
-      { "name": "公告设置", "type": "title" },
-      { "key": "alertEnabled", "name": "启用公告", "type": "switch", "default": false, "help": "在首页显示自定义公告" },
-      { "key": "alertTitle", "name": "公告标题", "type": "string", "default": "", "help": "公告的标题内容" },
-      { "key": "alertContent", "name": "公告内容", "type": "richtext", "default": "", "help": "公告的详细内容（支持简单 Markdown 格式）" },
-      { "name": "页面设置", "type": "title" },
-      { "key": "stopEarth", "name": "停止地球旋转", "type": "switch", "default": false, "help": "开启后地球默认不自动旋转，用户仍可手动拖拽查看" },
-      { "key": "hideEarth", "name": "隐藏地球", "type": "switch", "default": false, "help": "隐藏地球后仅显示总览卡片" },
-      { "key": "hideGeneralCard", "name": "隐藏头部", "type": "switch", "default": false, "help": "隐藏地球和总览卡片" },
-      { "name": "备案设置", "type": "title" },
-      { "key": "icpEnabled", "name": "显示备案号", "type": "switch", "default": false, "help": "在页脚显示网站备案号" },
-      { "key": "icpNumber", "name": "备案号", "type": "string", "default": "", "help": "网站备案号（如：京ICP备12345678号）" },
-      { "key": "icpUrl", "name": "备案跳转链接", "type": "string", "default": "https://beian.miit.gov.cn/", "help": "点击备案号跳转的链接地址" },
-      { "key": "policeEnabled", "name": "显示公安备案", "type": "switch", "default": false, "help": "在页脚显示公安备案信息" },
-      { "key": "policeNumber", "name": "公安备案号", "type": "string", "default": "", "help": "公安备案号（如：京公网安备 11010502000000号）" },
-      { "key": "policeUrl", "name": "公安备案跳转链接", "type": "string", "default": "", "help": "点击公安备案号跳转的链接地址，留空则不跳转" },
-      { "name": "自定义背景", "type": "title" },
-      { "key": "backgroundEnabled", "name": "启用自定义背景", "type": "switch", "default": false, "help": "启用后可设置自定义图片或视频作为页面背景" },
-      { "key": "backgroundType", "name": "背景类型", "type": "select", "default": "image", "options": "image,video", "help": "选择背景类型：图片或视频" },
-      { "key": "lightBackgroundUrl", "name": "亮色模式背景地址", "type": "string", "default": "", "help": "亮色模式下的背景图片/视频 URL" },
-      { "key": "darkBackgroundUrl", "name": "暗色模式背景地址", "type": "string", "default": "", "help": "暗色模式下的背景图片/视频 URL" },
-      { "key": "backgroundBlur", "name": "背景模糊半径", "type": "number", "default": 0, "help": "背景的高斯模糊半径（单位：px），0 表示不模糊" },
-      { "key": "backgroundOverlay", "name": "背景遮罩强度", "type": "number", "default": 0, "help": "背景遮罩强度（-100 到 100）：负数降低背景透明度，0 表示关闭，正数为黑色遮罩，绝对值越大效果越明显" }
+      {
+        "name": "基础设置",
+        "type": "title"
+      },
+      {
+        "key": "dataUpdateInterval",
+        "name": "数据更新间隔",
+        "type": "number",
+        "default": 3,
+        "help": "实时数据刷新间隔，单位：秒（建议 1-10 秒）"
+      },
+      {
+        "key": "rpcTransportMode",
+        "name": "RPC 连接模式",
+        "type": "select",
+        "default": "websocket",
+        "options": "websocket,http",
+        "help": "RPC 默认连接模式，推荐使用 websocket，若您无法使用 websocket 请选择 http"
+      },
+      {
+        "key": "defaultViewMode",
+        "name": "默认视图模式",
+        "type": "select",
+        "default": "card",
+        "options": "card,list",
+        "help": "节点列表的默认显示模式"
+      },
+      {
+        "name": "公告设置",
+        "type": "title"
+      },
+      {
+        "key": "alertEnabled",
+        "name": "启用公告",
+        "type": "switch",
+        "default": false,
+        "help": "在首页显示自定义公告"
+      },
+      {
+        "key": "alertTitle",
+        "name": "公告标题",
+        "type": "string",
+        "default": "",
+        "help": "公告的标题内容"
+      },
+      {
+        "key": "alertContent",
+        "name": "公告内容",
+        "type": "richtext",
+        "default": "",
+        "help": "公告的详细内容（支持简单 Markdown 格式）"
+      },
+      {
+        "name": "页面设置",
+        "type": "title"
+      },
+      {
+        "key": "stopEarth",
+        "name": "停止地球旋转",
+        "type": "switch",
+        "default": false,
+        "help": "开启后地球默认不自动旋转，用户仍可手动拖拽查看"
+      },
+      {
+        "key": "hideEarth",
+        "name": "隐藏地球",
+        "type": "switch",
+        "default": false,
+        "help": "隐藏地球后仅显示总览卡片"
+      },
+      {
+        "key": "hideGeneralCard",
+        "name": "隐藏头部",
+        "type": "switch",
+        "default": false,
+        "help": "隐藏地球和总览卡片"
+      },
+      {
+        "name": "备案设置",
+        "type": "title"
+      },
+      {
+        "key": "icpEnabled",
+        "name": "显示备案号",
+        "type": "switch",
+        "default": false,
+        "help": "在页脚显示网站备案号"
+      },
+      {
+        "key": "icpNumber",
+        "name": "备案号",
+        "type": "string",
+        "default": "",
+        "help": "网站备案号（如：京ICP备12345678号）"
+      },
+      {
+        "key": "icpUrl",
+        "name": "备案跳转链接",
+        "type": "string",
+        "default": "https://beian.miit.gov.cn/",
+        "help": "点击备案号跳转的链接地址"
+      },
+      {
+        "key": "policeEnabled",
+        "name": "显示公安备案",
+        "type": "switch",
+        "default": false,
+        "help": "在页脚显示公安备案信息"
+      },
+      {
+        "key": "policeNumber",
+        "name": "公安备案号",
+        "type": "string",
+        "default": "",
+        "help": "公安备案号（如：京公网安备 11010502000000号）"
+      },
+      {
+        "key": "policeUrl",
+        "name": "公安备案跳转链接",
+        "type": "string",
+        "default": "",
+        "help": "点击公安备案号跳转的链接地址，留空则不跳转"
+      },
+      {
+        "name": "自定义背景",
+        "type": "title"
+      },
+      {
+        "key": "backgroundEnabled",
+        "name": "启用自定义背景",
+        "type": "switch",
+        "default": false,
+        "help": "启用后可设置自定义图片或视频作为页面背景"
+      },
+      {
+        "key": "backgroundType",
+        "name": "背景类型",
+        "type": "select",
+        "default": "image",
+        "options": "image,video",
+        "help": "选择背景类型：图片或视频"
+      },
+      {
+        "key": "lightBackgroundUrl",
+        "name": "亮色模式背景地址",
+        "type": "string",
+        "default": "",
+        "help": "亮色模式下的背景图片/视频 URL"
+      },
+      {
+        "key": "darkBackgroundUrl",
+        "name": "暗色模式背景地址",
+        "type": "string",
+        "default": "",
+        "help": "暗色模式下的背景图片/视频 URL"
+      },
+      {
+        "key": "backgroundBlur",
+        "name": "背景模糊半径",
+        "type": "number",
+        "default": 0,
+        "help": "背景的高斯模糊半径（单位：px），0 表示不模糊"
+      },
+      {
+        "key": "darkBackgroundOverlay",
+        "name": "背景黑色遮罩强度",
+        "type": "number",
+        "default": 0,
+        "help": "黑色遮罩强度（0 到 100）：0 表示无遮罩，100 表示完全黑色遮罩"
+      },
+      {
+        "key": "darkOverlayInLightMode",
+        "name": "背景黑色遮罩在亮色模式下生效",
+        "type": "switch",
+        "default": true,
+        "help": "关闭后，下方【背景白色遮罩强度】设置才会生效"
+      },
+      {
+        "key": "lightBackgroundOverlay",
+        "name": "背景白色遮罩强度",
+        "type": "number",
+        "default": 0,
+        "help": "仅在【背景黑色遮罩在亮色模式下生效】关闭，且处于亮色模式时生效。白色遮罩强度（0 到 100）：0 表示无遮罩，100 表示完全白色遮罩"
+      }
     ]
   }
 }

--- a/src/components/Background.vue
+++ b/src/components/Background.vue
@@ -16,23 +16,24 @@ const backgroundStyle = computed(() => {
 })
 
 const backgroundContainerStyle = computed(() => {
-  const overlay = appStore.backgroundOverlay
-  if (overlay >= 0)
-    return {}
-
-  return { opacity: 1 - Math.abs(overlay) / 100 }
+  return {}
 })
 
 const overlayStyle = computed(() => {
   const overlay = appStore.backgroundOverlay
-  if (overlay <= 0)
+  if (overlay.value <= 0)
     return {}
 
-  return { backgroundColor: `rgba(0, 0, 0, ${overlay / 100})` }
+  if (overlay.type === 'dark') {
+    return { backgroundColor: `rgba(0, 0, 0, ${overlay.value / 100})` }
+  }
+  else {
+    return { backgroundColor: `rgba(255, 255, 255, ${overlay.value / 100})` }
+  }
 })
 
 const showBackground = computed(() => appStore.backgroundEnabled)
-const showBackgroundOverlay = computed(() => appStore.backgroundOverlay > 0)
+const showBackgroundOverlay = computed(() => appStore.backgroundOverlay.value > 0)
 const currentUrl = computed(() => appStore.currentBackgroundUrl)
 const backgroundType = computed(() => appStore.backgroundType)
 

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -224,12 +224,44 @@ const useAppStore = defineStore('app', () => {
     return 0
   })
 
-  const backgroundOverlay = computed<number>(() => {
+  const darkBackgroundOverlay = computed<number>(() => {
     const settings = publicSettings.value?.theme_settings
-    if (settings && typeof settings.backgroundOverlay === 'number' && settings.backgroundOverlay >= -100 && settings.backgroundOverlay <= 100) {
-      return settings.backgroundOverlay
+    if (settings && typeof settings.darkBackgroundOverlay === 'number' && settings.darkBackgroundOverlay >= 0 && settings.darkBackgroundOverlay <= 100) {
+      return settings.darkBackgroundOverlay
     }
     return 0
+  })
+
+  const lightBackgroundOverlay = computed<number>(() => {
+    const settings = publicSettings.value?.theme_settings
+    if (settings && typeof settings.lightBackgroundOverlay === 'number' && settings.lightBackgroundOverlay >= 0 && settings.lightBackgroundOverlay <= 100) {
+      return settings.lightBackgroundOverlay
+    }
+    return 0
+  })
+
+  // 读取【背景黑色遮罩在亮色模式下生效】开关，默认 true
+  const darkOverlayInLightMode = computed<boolean>(() => {
+    const settings = publicSettings.value?.theme_settings
+    if (settings && typeof settings.darkOverlayInLightMode === 'boolean') {
+      return settings.darkOverlayInLightMode
+    }
+    return true
+  })
+
+  // 当前模式下实际生效的遮罩强度和类型
+  // 规则：
+  //   暗色模式：始终使用黑色遮罩（darkBackgroundOverlay）
+  //   亮色模式 + darkOverlayInLightMode=true：同样使用黑色遮罩，视觉效果与暗色模式一致
+  //   亮色模式 + darkOverlayInLightMode=false：使用白色遮罩（lightBackgroundOverlay）
+  const backgroundOverlay = computed<{ value: number, type: 'dark' | 'light' }>(() => {
+    if (isDark.value) {
+      return { value: darkBackgroundOverlay.value, type: 'dark' }
+    }
+    if (darkOverlayInLightMode.value) {
+      return { value: darkBackgroundOverlay.value, type: 'dark' }
+    }
+    return { value: lightBackgroundOverlay.value, type: 'light' }
   })
 
   // 当 publicSettings 加载后，如果 localStorage 没有保存过视图模式或值为非法值，使用默认值
@@ -307,6 +339,9 @@ const useAppStore = defineStore('app', () => {
     currentBackgroundUrl,
     backgroundBlur,
     backgroundOverlay,
+    darkBackgroundOverlay,
+    lightBackgroundOverlay,
+    darkOverlayInLightMode,
     isLoggedIn,
     publicSettings,
     connectionError,


### PR DESCRIPTION
关于 https://github.com/Tokinx/komari-theme-emerald/issues/3#issuecomment-4585829296 

我改成这样了：

背景黑色遮罩在亮色模式下生效：默认是打开的状态。

<img width="799" height="397" alt="image" src="https://github.com/user-attachments/assets/1385a9aa-612e-41b6-b4df-0169b854a523" />

可以同时满足背景图在亮色模式下可能也想要加黑色遮罩，或者希望区分模式，两种需求。

希望大佬 merge

ps：还是没改版本号